### PR TITLE
Update guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "guzzlehttp/guzzle": "6.2.1"
+        "guzzlehttp/guzzle": "^6.2.1"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Version was locked at 6.2.1, which will lead to errors when we move on from PHP7.1.
Updated the version to allow higher versions of guzzle.